### PR TITLE
Downgraded rbush to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "@turf/bbox": "*",
     "@turf/helpers": "6.x",
     "@turf/meta": "6.x",
-    "rbush": "*"
+    "rbush": "^2.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ const test = require('tape');
 const path = require('path');
 const load = require('load-json-file');
 const write = require('write-json-file');
-const bboxPolygon = require('@turf/bbox-polygon');
+const bboxPolygon = require('@turf/bbox-polygon').default;
 const { polygon, featureCollection, polygons } = require('@turf/helpers');
 const geojsonRbush = require('./').default;
 


### PR DESCRIPTION
Downgraded rbush to 2.x.

Rbush has recently upgraded to 3.x which includes breaking changes and you have to use the API differently now. All existing unit tests passed with this change, but I did had to to make a change to BBox import for the tests to work. 

Fixes #8 