### PR TITLE
Migrate to @types/geojson

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
-import { BBox, Feature, FeatureCollection, Geometry, GeometryCollection, GeometryObject, GeoJsonProperties } from 'geojson'
+import { BBox, Feature, FeatureCollection, Geometry, GeoJsonProperties } from 'geojson'
 
-declare class RBush<G extends GeometryObject, P extends GeoJsonProperties> {
+declare class RBush<G extends Geometry, P extends GeoJsonProperties> {
     insert(feature: Feature<G, P>): RBush<G, P>;
     load(features: FeatureCollection<G, P> | Feature<G, P>[]): RBush<G, P>;
     remove(feature: Feature<G, P>, equals?: (a: Feature<G, P>, b: Feature<G, P>) => boolean): RBush<G, P>;
@@ -15,5 +15,5 @@ declare class RBush<G extends GeometryObject, P extends GeoJsonProperties> {
 /**
  * https://github.com/mourner/rbush
  */
-export default function rbush<G extends GeometryObject = Geometry | GeometryCollection, P = any>(maxEntries?: number): RBush<G, P>;
+export default function rbush<G extends Geometry = Geometry, P = any>(maxEntries?: number): RBush<G, P>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
-import { BBox, Feature, FeatureCollection, Geometry, Properties } from '@turf/helpers'
+import { BBox, Feature, FeatureCollection, Geometry, GeometryCollection, GeometryObject, GeoJsonProperties } from 'geojson'
 
-declare class RBush<G extends any, P extends any> {
+declare class RBush<G extends GeometryObject, P extends GeoJsonProperties> {
     insert(feature: Feature<G, P>): RBush<G, P>;
     load(features: FeatureCollection<G, P> | Feature<G, P>[]): RBush<G, P>;
     remove(feature: Feature<G, P>, equals?: (a: Feature<G, P>, b: Feature<G, P>) => boolean): RBush<G, P>;
@@ -15,5 +15,5 @@ declare class RBush<G extends any, P extends any> {
 /**
  * https://github.com/mourner/rbush
  */
-export default function rbush<G = any, P = any>(maxEntries?: number): RBush<G, P>;
+export default function rbush<G extends GeometryObject = Geometry | GeometryCollection, P = any>(maxEntries?: number): RBush<G, P>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,5 +15,5 @@ declare class RBush<G extends Geometry, P extends GeoJsonProperties> {
 /**
  * https://github.com/mourner/rbush
  */
-export default function rbush<G extends Geometry = Geometry, P = any>(maxEntries?: number): RBush<G, P>;
+export default function rbush<G = Geometry, P = GeoJsonProperties>(maxEntries?: number): RBush<G, P>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,5 +15,5 @@ declare class RBush<G extends Geometry, P extends GeoJsonProperties> {
 /**
  * https://github.com/mourner/rbush
  */
-export default function rbush<G = Geometry, P = GeoJsonProperties>(maxEntries?: number): RBush<G, P>;
+export default function rbush<G extends Geometry = Geometry, P = GeoJsonProperties>(maxEntries?: number): RBush<G, P>;
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@turf/bbox": "*",
     "@turf/helpers": "6.x",
     "@turf/meta": "6.x",
+    "@types/geojson": "7946.0.8",
     "rbush": "^2.0.0"
   }
 }

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,5 @@
-import { BBox, point, polygon, featureCollection, Polygon} from '@turf/helpers'
+import { point, polygon, featureCollection } from '@turf/helpers'
+import { BBox } from 'geojson'
 import rbush from './'
 
 // Fixtures


### PR DESCRIPTION
Hi @DenisCarriere, please consider this PR which resolves a blocker error I'm running into over in Turf.

I'm [working on a PR in Turf](https://github.com/Turfjs/turf/pull/2158) to switch from the internal geojson types you developed, back to using `@types/geojson`, and to stop exporting them from turf-helpers.  The intention is that individual turf packages and external repos like this one should just migrate to using @types/geojson directly.

I know you've had your hands on all this with Turf years past, and had your eyes on a migration like I'm doing, so I'm happy to provide a little more detail.

Because geojson-rbush currently imports its geojson types via turf-helpers, and I've removed those exports from turf-helpers in my PR, and Turf uses yarn workspaces with symlinks in node_modules to turf packages, it's causing a circular issue where when I try to build, geojson-rbush can't find the types it needs from helpers.

Couple additional thoughts:
- Turf will need a new release if you could publish one?  I'm hoping to land this asap to unblock.
- I did not include lockfile changes in this PR.  The changes my yarn and npm are generating are substantial, because the current lockfiles are an older version.  Perhaps you could add?

Thanks, and I appreciate all the work you've done in the past.  Just carrying the torch a bit.