### PR TITLE
Use es5 rbush bundle

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var rbush = require('rbush');
+var rbush = require('rbush/rbush');
 var helpers = require('@turf/helpers');
 var meta = require('@turf/meta');
 var turfBBox = require('@turf/bbox').default;


### PR DESCRIPTION
@DenisCarriere thanks so much for the quick release of 3.2.0!  I found one new but small blocker for use in Turf.  With the addition of rbush 3.x, the non es5 version of that library is being imported, and Turf requires es5 (for now at least).

Please consider this PR which imports the non-minified es5 build, and publishing a point release.  I confirmed locally this will fix the issue.  Thanks!